### PR TITLE
Check default values with `confirmation` [See #137]

### DIFF
--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -1,9 +1,16 @@
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { validate } from 'ember-validators';
+import { assign } from 'ember-platform';
+
 
 export default function validateConfirmation(options = {}) {
-  return (key, newValue, _oldValue, changes/*, _content*/) => {
-    let result = validate('confirmation', newValue, options, changes, key);
+  return (key, newValue, _oldValue, changes , content = {}) => {
+    // Combine the changes on top of the content so that we evaluate against both default values
+    // and valid changes. `changes` only has valid changes that have been made and won't include
+    // default values
+    let model = assign(content, changes);
+
+    let result = validate('confirmation', newValue, options, model, key);
     return (result === true) ? true : buildMessage(key, result);
   };
 }

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -61,3 +61,16 @@ test('it accepts an `allowBlank` option', function(assert) {
 
   assert.equal(validator(key, ''), true, 'Empty string is accepted');
 });
+
+test('It looks for default values as well as "changes" values', function(assert) {
+  assert.expect(2);
+
+  let password = '1234567';
+  let content = { password };
+  let key = 'passwordConfirmation';
+  let opts = { on: 'password' };
+  let validator = validateConfirmation(opts);
+
+  assert.equal(validator(key, 'foo', undefined, {}, content), buildMessage(key, { type: 'confirmation', context: opts }));
+  assert.equal(validator(key, password, undefined, {}, content), true);
+});


### PR DESCRIPTION
Addresses part of #137 

The `confirmation` validation only looks to the `changes` object
for the state of other fields. However, this may result in a
false positive when the initial value of the field matches
what's in the `confirmation` field, because `changes` only contains
fields with new data that is valid.

This doesn't fix the issue of an invalid field that matches
what's in the confirmation field. Technically, if an invalid field
matches what's in the confirmation field there should be no error.
A more fundamental change inside of `ember-changeset` is required
for this to work properly.