### PR TITLE
H/fix messaging bugs

### DIFF
--- a/addon/utils/get-messages.js
+++ b/addon/utils/get-messages.js
@@ -5,7 +5,7 @@ import withDefaults from 'ember-changeset-validations/utils/with-defaults';
 
 const { A: emberArray, isPresent } = Ember;
 const { keys } = Object;
-const matchRegex = /validations\/messages$/gi;
+const matchRegex = /\/validations\/messages$/gi;
 
 let cachedRef = null;
 

--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -17,25 +17,21 @@ const assign = Ember.assign || Ember.merge;
 export default function buildMessage(key, result) {
   let messages = getMessages();
   let description = messages.getDescriptionFor(key);
-
-  if (result.message) {
-    return result.message;
-  }
-
   let { type, value, context = {} } = result;
+  let message;
 
-  if (context.message) {
-    let message = context.message;
-
-    if (typeOf(message) === 'function') {
-      let builtMessage = message(key, type, value, context);
-      assert('Custom message function must return a string', typeOf(builtMessage) === 'string');
-
-      return builtMessage;
-    }
-
-    return messages.formatMessage(message, assign({ description }, context));
+  if (context.message || result.message) {
+    message = context.message || result.message;
+  } else {
+    message = get(messages, type);
   }
 
-  return messages.formatMessage(get(messages, type), assign({ description }, context));
+  if (typeOf(message) === 'function') {
+    let builtMessage = message(key, type, value, context);
+    assert('Custom message function must return a string', typeOf(builtMessage) === 'string');
+
+    return messages.formatMessage(builtMessage, assign({ description }, context));
+  }
+
+  return messages.formatMessage(message, assign({ description }, context));
 }

--- a/tests/dummy/app/validations/messages.js
+++ b/tests/dummy/app/validations/messages.js
@@ -5,7 +5,9 @@ export default {
   confirmation: "[CUSTOM] {description} doesn't match {on}",
   accepted: '[CUSTOM] {description} must be accepted',
   empty: "[CUSTOM] {description} can't be empty",
-  blank: '[CUSTOM] {description} must be blank',
+  blank(key) {
+    return `[CUSTOM] key: ${key} - {description} must be blank`;
+  },
   present: "[CUSTOM] {description} can't be blank",
   collection: '[CUSTOM] {description} must be a collection',
   singular: "[CUSTOM] {description} can't be a collection",

--- a/tests/unit/helpers/changeset-test.js
+++ b/tests/unit/helpers/changeset-test.js
@@ -38,16 +38,18 @@ test('it composes validations and uses custom validation messages', function(ass
   };
   let changesetInstance = changeset([user, userValidations]);
 
-  changesetInstance.set('firstName', 'helloworldjimbob');
-  assert.deepEqual(changesetInstance.get('error.firstName.validation'), ['[CUSTOM] First name must be between 1 and 8 characters']);
+  `[CUSTOM] key: ${key} value: ${value} - {description} must be blank`;
+  var firstNameVal = 'helloworldjimbob';
+  changesetInstance.set('firstName', firstNameVal);
+  assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] First name must be between 1 and 8 characters"]);
   assert.ok(changesetInstance.get('isInvalid'), 'should be invalid with wrong length first name');
 
   changesetInstance.set('firstName', '');
-  assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] First name can't be blank", '[CUSTOM] First name must be between 1 and 8 characters']);
+  assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] key: firstName - First name can't be blank", '[CUSTOM] First name must be between 1 and 8 characters']);
   assert.ok(changesetInstance.get('isInvalid'), 'should be invalid with blank first name');
 
   changesetInstance.set('lastName', '');
-  assert.deepEqual(changesetInstance.get('error.lastName.validation'), ["[CUSTOM] Last name can't be blank"]);
+  assert.deepEqual(changesetInstance.get('error.lastName.validation'), ["[CUSTOM] key: lastName - Last name can't be blank"]);
   assert.ok(changesetInstance.get('isInvalid'), 'should be invalid with blank last name');
 
   changesetInstance.set('firstName', 'Jim');
@@ -121,7 +123,7 @@ test('it works with models that are promises', function(assert) {
 
   return changeset([user, userValidations]).then((changesetInstance) => {
     changesetInstance.validate().then(() => {
-      assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] First name can't be blank"]);
+      assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] key: firstName - First name can't be blank"]);
       assert.ok(changesetInstance.get('isInvalid'), 'should be invalid with wrong length first name');
 
       changesetInstance.set('firstName', 'Jim');

--- a/tests/unit/helpers/changeset-test.js
+++ b/tests/unit/helpers/changeset-test.js
@@ -38,9 +38,7 @@ test('it composes validations and uses custom validation messages', function(ass
   };
   let changesetInstance = changeset([user, userValidations]);
 
-  `[CUSTOM] key: ${key} value: ${value} - {description} must be blank`;
-  var firstNameVal = 'helloworldjimbob';
-  changesetInstance.set('firstName', firstNameVal);
+  changesetInstance.set('firstName', 'helloworldjimbob');
   assert.deepEqual(changesetInstance.get('error.firstName.validation'), ["[CUSTOM] First name must be between 1 and 8 characters"]);
   assert.ok(changesetInstance.get('isInvalid'), 'should be invalid with wrong length first name');
 


### PR DESCRIPTION
## Bugs

#### When you have an application that is listed lower in the registry than `ember-validations/messages`, custom messages module will fail

**Reproduction steps**
1. Generate new ember app that starts with a lower alpha character - i.e `ember new zebra-app`
2. Install all dependencies needed for `ember-changeset-validations`
3. Provide a custom messages module i.e. - `zebra-app/app/validations/messages`
4. Try to use validations, and you will see that custom messages does not get used

#### When you provide a function to the custom messages module, it does not get called

**Reproduction steps**
1. Generate new ember app (unless the above bug is solved, it must be a higher alpha character like "apple-app")
2. Install all dependencies needed for `ember-changeset-validations`
3. Provide a custom messages module with a function as one of the keys for a custom message
4. Try to use the validation provided in the custom messages file as a function, and you will see that custom message fails

## Changes proposed in this pull request
- Fixes the regex lookup of the custom messages module. Will fail in applications that are listed lower than .
- fixes the ability to provide functions in the custom messages module
