### PR TITLE
Fix #141 - make buildMessage backwards compatible

### DIFF
--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -24,6 +24,12 @@ export default function buildMessage(key, result) {
 
   let { type, value, context = {} } = result;
 
+  if (typeOf(result) === 'string') {
+    type = result;
+    value = arguments[2];
+    context = arguments[3];
+  }
+
   if (context.message) {
     let message = context.message;
 

--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -27,7 +27,7 @@ export default function buildMessage(key, result) {
   if (typeOf(result) === 'string') {
     type = result;
     value = arguments[2];
-    context = arguments[3];
+    context = arguments[3] || {};
   }
 
   if (context.message) {

--- a/tests/unit/utils/validation-errors-test.js
+++ b/tests/unit/utils/validation-errors-test.js
@@ -29,6 +29,14 @@ test('#buildMessage builds a custom message if custom message is string', functi
   );
 });
 
+test('#buildMessage does not break compatibility', function(assert) {
+  assert.equal(
+    buildMessage('firstName', 'custom', 'testValue', { message: "{description} can't be equal to {foo}", foo: 'foo' }),
+    "First name can't be equal to foo",
+    'Built message is generated correctly'
+  );
+});
+
 test('#buildMessage builds a custom message if custom message is a function', function(assert) {
   assert.expect(5);
 


### PR DESCRIPTION
Its a quick fix.  There may be a better way, but this fixes it for me.  Maybe a deprecation warning should be added or something..

Fixes #141