### PR TITLE
Fix for changeset helper not preserving options (i.e. skipValidate)

### DIFF
--- a/addon/helpers/changeset.js
+++ b/addon/helpers/changeset.js
@@ -6,20 +6,20 @@ import isPromise from 'ember-changeset/utils/is-promise';
 
 const { Helper: { helper } } = Ember;
 
-export function changeset([model, validationMap]) {
+export function changeset([model, validationMap], options) {
   if (isObject(validationMap)) {
     if (isPromise(model)) {
-      return model.then((resolved) => new Changeset(resolved, lookupValidator(validationMap), validationMap));
+      return model.then((resolved) => new Changeset(resolved, lookupValidator(validationMap), validationMap, options));
     }
 
-    return new Changeset(model, lookupValidator(validationMap), validationMap);
+    return new Changeset(model, lookupValidator(validationMap), validationMap, options);
   }
 
   if (isPromise(model)) {
-    return model.then((resolved) => new Changeset(resolved, validationMap));
+    return model.then((resolved) => new Changeset(resolved, validationMap, options));
   }
 
-  return new Changeset(model, validationMap);
+  return new Changeset(model, validationMap, options);
 }
 
 export default helper(changeset);

--- a/tests/unit/helpers/changeset-test.js
+++ b/tests/unit/helpers/changeset-test.js
@@ -131,3 +131,20 @@ test('it works with models that are promises', function(assert) {
     });
   });
 });
+
+test('it preserves options (i.e. skipValidate)', function(assert) {
+  let User = EmberObject.extend({
+    firstName: null,
+    lastName: null
+  });
+  let user = resolve(User.create());
+  let userValidations = {
+    firstName: validatePresence(true),
+    lastName: validatePresence(true)
+  };
+  let options = { skipValidate: true }
+
+  return changeset([user, userValidations], options ).then((changesetInstance) => {
+    assert.deepEqual(changesetInstance.get('_options'), options);
+  });
+});


### PR DESCRIPTION
Previously passing `skipValidate=true` in the template would do
nothing, as the option wasn’t passed to to the Changeset constructor.
