### PR TITLE
move ember-cli-htmlbars to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "ember-changeset": "1.4.2-beta.1",
     "ember-cli-babel": "^6.0.0",
-    "ember-cli-htmlbars": "^1.1.1",
     "ember-get-config": "^0.2.4",
     "ember-validators": "^1.0.0"
   },
@@ -36,6 +35,7 @@
     "ember-cli-blueprint-test-helpers": "^0.13.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",


### PR DESCRIPTION
This was done as part of https://github.com/poteto/ember-changeset-validations/pull/129 but I'm not able to see any reason for this and the tests all seem to pass at this point
