### PR TITLE
Updates ember-validators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: required
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-get-config": "^0.2.4",
-    "ember-validators": "^1.0.0"
+    "ember-validators": "^1.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2501,9 +2501,9 @@ ember-try@^0.2.23:
     rsvp "^3.0.17"
     semver "^5.1.0"
 
-ember-validators@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-1.1.1.tgz#34b06f7c4bde4e57c30cb9dfc6566647c1c140c1"
+ember-validators@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-1.2.0.tgz#b4bc9aeaf97921d80c41b7dc21acca288d1216ae"
   dependencies:
     ember-cli-babel "^6.9.2"
     ember-require-module "^0.2.0"


### PR DESCRIPTION
## Changes proposed in this pull request

Updates ember-validators. Motivation for this is ember-validators 1.0.0 has ember-cli-babel 5.x as a dependency which throws a deprecation warning in newer version of Ember. We are striving to eliminate older versions of babel from our app.
