### PR TITLE
chore(deprecation): handle the ember-polyfills.deprecate-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,15 +352,15 @@ export default {
 };
 ```
 
-You can easily import other validations and combine them using `Ember.assign` or `Ember.merge`.
+You can easily import other validations and combine them using `Ember.assign`.
 
 ```js
 // validations/adult.js
-import Ember from 'ember';
 import UserValidations from './user';
 import { validateNumber } from 'ember-changeset-validations/validators';
 
-const { assign } = Ember;
+import { assign } from '@ember/polyfills';
+
 
 export const AdultValidations = {
   age: validateNumber({ gt: 18 })

--- a/addon/utils/messages.js
+++ b/addon/utils/messages.js
@@ -1,11 +1,7 @@
-import Ember from 'ember';
 import _Messages from 'ember-validators/messages';
+import { assign } from '@ember/polyfills';
+import { capitalize, dasherize } from '@ember/string';
 
-const {
-  String: { dasherize, capitalize }
-} = Ember;
-
-const assign = Ember.assign || Ember.merge;
 const Messages = assign({}, _Messages);
 
 export default assign(Messages, {

--- a/addon/utils/validation-errors.js
+++ b/addon/utils/validation-errors.js
@@ -3,19 +3,16 @@
  * Copyright 2016, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-import Ember from 'ember';
 import {
-  get, getWithDefault
+  get,
+  getWithDefault
 } from '@ember/object';
-import getMessages from 'ember-changeset-validations/utils/get-messages';
+
+import { assert } from '@ember/debug';
+import { assign } from '@ember/polyfills';
 import config from 'ember-get-config';
-
-const {
-  assert,
-  typeOf
-} = Ember;
-
-const assign = Ember.assign || Ember.merge;
+import getMessages from 'ember-changeset-validations/utils/get-messages';
+import { typeOf } from '@ember/utils';
 
 export default function buildMessage(key, result) {
   let returnsRaw = getWithDefault(config, 'changeset-validations.rawOutput', false);

--- a/addon/utils/with-defaults.js
+++ b/addon/utils/with-defaults.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const assign = Ember.merge || Ember.assign;
+import { assign } from '@ember/polyfills';
 
 /**
  * Create a new object with defaults


### PR DESCRIPTION
Migrated usage to assign as recommended by https://www.emberjs.com/deprecations/v3.x/#toc_ember-polyfills-deprecate-merge