### PR TITLE
Add `on` option for validatePresence

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ Validates presence/absence of a value.
 }
 ```
 
+#### `on` option for `presence`
+
+Only validates for presence if any of the other values are present
+```js
+{
+  password: validatePresence({ presence: true, on: 'ssn' })
+  password: validatePresence({ presence: true, on: [ 'ssn', 'email', 'address' ] })
+  password: validatePresence({ presence: false, on: 'alternative-login' })
+}
+```
+
 **[⬆️ back to top](#validator-api)**
 
 #### `length`

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -2,7 +2,7 @@ import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { validate } from 'ember-validators';
 
 export default function validatePresence(options = {}) {
-  let targets
+  let targets;
   if (typeof options === 'boolean') {
     options = { presence: options };
   } else {

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -1,17 +1,22 @@
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { validate } from 'ember-validators';
 
-export default function validatePresence(options = {}) {
+export default function validatePresence(options) {
   let targets;
   if (typeof options === 'boolean') {
     options = { presence: options };
-  } else {
-    targets = typeof options.on === 'string' ? [ options.on ] : options.on;
+  } else if (options && options.on !== undefined) {
+    if (typeof options.on === 'string') {
+      targets = [ options.on ];
+    } else if (Array.isArray(options.on)) {
+      targets = options.on;
+    }
+
     delete options.on;
   }
 
-  return (key, value, oldValue, changes, content) => {
-    if (targets && !targets.some((target) => changes[target] || ( changes[target] === undefined && content[target]))) {
+  return (key, value, _oldValue, changes, content) => {
+    if (targets && !targets.some((target) => changes[target] || (changes[target] === undefined && content[target]))) {
       return true;
     }
 

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -1,12 +1,20 @@
 import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import { validate } from 'ember-validators';
 
-export default function validatePresence(options) {
+export default function validatePresence(options = {}) {
+  let targets
   if (typeof options === 'boolean') {
     options = { presence: options };
+  } else {
+    targets = typeof options.on === 'string' ? [ options.on ] : options.on;
+    delete options.on;
   }
 
-  return (key, value) => {
+  return (key, value, oldValue, changes, content) => {
+    if (targets && !targets.some((target) => changes[target] || ( changes[target] === undefined && content[target]))) {
+      return true;
+    }
+
     let result = validate('presence', value, options, null, key);
 
     if (typeof result === 'boolean' || typeof result === 'string') {

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -44,6 +44,75 @@ test('it accepts a false `presence` option', function(assert) {
   assert.equal(validator(key, 'a'), buildMessage(key, { type: 'blank' }));
 });
 
+function presenceOnTests(assert, options) {
+  let key = 'firstName';
+  let targets = typeof options.on === 'string' ? [ options.on ] : options.on
+  let validator = validatePresence(options)
+  let expectedIfEmpty = options.presence ? buildMessage(key, { type: 'present' }) : true
+  let expectedIfPresent = options.presence ? true : buildMessage(key, { type: 'blank' })
+
+  assert.equal(validator(key, undefined, '', {}, {}), true);
+  assert.equal(validator(key, null, '', {}, {}), true);
+  assert.equal(validator(key, '', '', {}, {}), true);
+  assert.equal(validator(key, 'a', '', {}, {}), true);
+
+  for (let target of targets) {
+    assert.equal(validator(key, '', '', {}, { [target]: undefined }), true)
+    assert.equal(validator(key, '', '', {}, { [target]: null }), true)
+    assert.equal(validator(key, '', '', {}, { [target]: '' }), true)
+
+    assert.equal(validator(key, '', '', { [target]: undefined }, {}), true)
+    assert.equal(validator(key, '', '', { [target]: null }, {}), true)
+    assert.equal(validator(key, '', '', { [target]: '' }, {}), true)
+
+    assert.equal(validator(key, '', '', { [target]: 'a'}, {}), expectedIfEmpty)
+    assert.equal(validator(key, 'a', '', { [target]: 'a'}, {}), expectedIfPresent)
+
+    // if the target is blank on the changes, it ignores the value in the content
+    assert.equal(validator(key, '', '', { [target]: ''}, { [target]: 'a' }), true)
+    assert.equal(validator(key, 'a', '', { [target]: ''}, { [target]: 'a' }), true)
+  }
+
+  let allTargets = {}
+  let allBlankTargets = {}
+
+  for (let target of targets) {
+    allTargets[target] = 'a'
+    allBlankTargets[target] = ''
+  }
+
+  assert.equal(validator(key, '', '', allTargets, {}), expectedIfEmpty)
+  assert.equal(validator(key, 'a', '', allTargets, {}), expectedIfPresent)
+  assert.equal(validator(key, '', '', {}, allTargets), expectedIfEmpty)
+  assert.equal(validator(key, 'a', '', {}, allTargets), expectedIfPresent)
+  assert.equal(validator(key, '', '', allBlankTargets, allTargets), true)
+}
+
+test('it accepts a string `on` option and true presence', function(assert) {
+  presenceOnTests(assert, { presence: true, on: 'dependent' });
+});
+
+test('it accepts an array `on` option and true presence', function(assert) {
+  presenceOnTests(assert, { presence: true, on: [ 'dependent' ] });
+});
+
+test('it accepts an multiple string array `on` option and true presence', function(assert) {
+  presenceOnTests(assert, { presence: true, on: [ 'dependent1', 'dependent2' ] });
+});
+
+test('it accepts a string `on` option and false presence', function(assert) {
+  presenceOnTests(assert, { presence: false, on: 'dependent' });
+});
+
+test('it accepts an array `on` option and false presence', function(assert) {
+  presenceOnTests(assert, { presence: false, on: [ 'dependent' ] });
+});
+
+test('it accepts an multiple string array `on` option and false presence', function(assert) {
+  presenceOnTests(assert, { presence: false, on: [ 'dependent1', 'dependent2' ] });
+});
+
+
 test('it can output a custom message string', function(assert) {
   let key = 'firstName';
   let options = { presence: true, message: '{description} should be present' };


### PR DESCRIPTION
Closes #189 .

## Changes proposed in this pull request

This adds the `on` option for `validatePresence` as shown in the updated README.  For instance,

` password: validatePresence({ presence: true, on: 'ssn' })`

would validate the presence of `password` IF `ssn` is found in the changes or the content.  One caveat: If an entry appears in the content, but is changed to be blank in the changes, it will skip validation.

If you would rather this be a separate validator, I can change this fairly easily.