### PR TITLE
Locking ember-changeset version to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-changeset": "^2.2.1",
+    "ember-changeset": "2.2.1",
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-get-config": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-changeset-validations",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Validations for ember-changeset",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Locking ember-changeset to 2.2.1 version as 2.2.2 release has caused failing tests.
https://github.com/poteto/ember-changeset-validations/issues/201