### PR TITLE
imports isPromise from validated-changeset (#223)

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -2,7 +2,7 @@ import { isEmpty } from '@ember/utils';
 import { isArray } from '@ember/array';
 import wrapInArray from 'ember-changeset-validations/utils/wrap';
 import handleMultipleValidations from 'ember-changeset-validations/utils/handle-multiple-validations';
-import isPromise from 'ember-changeset/utils/is-promise';
+import { isPromise } from 'validated-changeset';
 
 export default function lookupValidator(validationMap = {}) {
   return ({ key, newValue, oldValue, changes, content }) => {

--- a/addon/utils/handle-multiple-validations.js
+++ b/addon/utils/handle-multiple-validations.js
@@ -2,7 +2,7 @@ import { A as emberArray } from '@ember/array';
 import { all } from 'rsvp';
 import { get } from '@ember/object';
 import { typeOf } from '@ember/utils';
-import isPromise from 'ember-changeset/utils/is-promise';
+import { isPromise } from 'validated-changeset';
 
 /**
  * Rejects `true` values from an array of validations. Returns `true` when there


### PR DESCRIPTION
This Pull Request removes the dependancy on `ember-changeset/utils/is-promise`, which no longer exists, and instead imports it from the `validated-changeset` package.

✨ 

This hopefully addresses #223