### PR TITLE
Do not assign changes to original content in confirmation

### DIFF
--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -8,7 +8,7 @@ export default function validateConfirmation(options = {}) {
     // Combine the changes on top of the content so that we evaluate against both default values
     // and valid changes. `changes` only has valid changes that have been made and won't include
     // default values
-    let model = assign(content, changes);
+    let model = assign({}, content, changes);
 
     let result = validate('confirmation', newValue, options, model, key);
     return (result === true) ? true : buildMessage(key, result);


### PR DESCRIPTION
In #219, the assign was introduced. This is trying to mutate the underlying model. This issue became clear on a glimmer component.

The error message:

```
Uncaught Error: Assertion Failed: You attempted to update [object Object].newPassword to "dd", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
```


cc @@snewcomer. 

Here is a reproduction if you would like to see the error: https://github.com/josemarluedke/--changeset-glimmer/commit/9df7e8483eb6b2c79c8efe17c6723348e9929bf3