### PR TITLE
Allow super duper secrete "value" key in changeset object tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "contributors": "npx contributor-faces -e \"(*-bot|*\\[bot\\]|*-tomster|homu|bors)\""
   },
   "dependencies": {
-    "ember-changeset": "^3.5.1",
+    "ember-changeset": "^3.5.3",
     "ember-cli-babel": "^7.8.0",
     "ember-cli-htmlbars": "^4.0.5",
     "ember-get-config": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4261,15 +4261,15 @@ ember-auto-import@^1.5.2, ember-auto-import@^1.5.3:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-changeset@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-3.5.1.tgz#76cac062f64fa487e54bfe2b511a093f7d7c042f"
-  integrity sha512-iRHcv2+6Qpud6uYG3pI+JI5Rybdtmlj+MzP/QHjCdD0G2K74kq1VZLv3fHiktVmXP32ka7p7sPbrIWBDAHJaUQ==
+ember-changeset@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-3.5.3.tgz#26a4b5f58aa8296db26d2136508c424a9ab73761"
+  integrity sha512-s7poVs67qJaZHcxllGGJiRcqcBCKDLyezKc6kWhRxtYMwa/bH523HELFSWs0vdJrHwDIVg3+tl+e3dnWzdewUg==
   dependencies:
     "@glimmer/tracking" "^1.0.0"
     ember-auto-import "^1.5.2"
     ember-cli-babel "^7.19.0"
-    validated-changeset "~0.6.3"
+    validated-changeset "~0.6.5"
 
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   version "1.1.0"
@@ -10265,10 +10265,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validated-changeset@~0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.6.3.tgz#f7ee83b5db29f4b2828c20b9c9b3d83acb01e7de"
-  integrity sha512-xYtsRu8NuVPzesyGprokEiWBAn9h4rCIOfGOGYCjByw6y2LJK6SIuF1YCfCKA8gUoz0NIf4tdrnzDj0xbgGjoA==
+validated-changeset@~0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.6.5.tgz#04b04e6a1fe32e937e18ff99c56e26152097ad7e"
+  integrity sha512-kppw9aeCvcEYXAWvPVQBWkOFu4dI/pdgtXZ84P+RnuKBiuVZE7rmet7q2Y/Eih75BvIUmt/6qFA4SQR86H/9/A==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
https://github.com/poteto/ember-changeset/pull/497

close #110 

Effectively, while iterating the object tree we were checking for `value` (as an indication there is a Change).  However, we can just detect via `instanceof Change`