### PR TITLE
Allow for custom message handlers when using the date validator.

### DIFF
--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -14,6 +14,7 @@ export default function validateDate(options = {}) {
   return (key, value) => {
     let { allowBlank } = options;
     let { before, onOrBefore, after, onOrAfter, message } = options;
+    let type = 'date'
 
     if (allowBlank && (typeof value === 'undefined' || value === null)) {
       return true;
@@ -22,38 +23,46 @@ export default function validateDate(options = {}) {
     let date = toDate(value);
 
     if (!isValidDate(date)) {
-      return buildMessage(key, { type: 'date', value: 'not a date', message });
+      return buildMessage(key, { type, value: 'not a date', context: { value, message } });
     }
 
     if (before) {
       before = toDate(before);
+      message = message || `[BEFORE] date is NOT before ${value}`;
+      type = 'before'
 
       if (date >= before) {
-        return buildMessage(key, { value, message: message || `[BEFORE] date is NOT before ${value}` });
+        return buildMessage(key, { type, value, context: { before, message } });
       }
     }
 
     if (onOrBefore) {
       onOrBefore = toDate(onOrBefore);
+      message = message || `[ON OR BEFORE] date is NOT on or before ${value}`;
+      type = 'onOrBefore'
 
       if (date > onOrBefore) {
-        return buildMessage(key, { value, message: message || `[ON OR BEFORE] date is NOT on or before ${value}` });
+        return buildMessage(key, { type, value, context: { onOrBefore, message } });
       }
     }
 
     if (after) {
       after = toDate(after);
+      message = message || `[AFTER] date is NOT after ${value}`;
+      type = 'after'
 
       if (date <= after) {
-        return buildMessage(key, { value, message: message || `[AFTER] date is NOT after ${value}` });
+        return buildMessage(key, { type, value, context: { after, message } });
       }
     }
 
     if (onOrAfter) {
       onOrAfter = toDate(onOrAfter);
+      message = message || `[ON OR AFTER] date is NOT on or after ${value}`;
+      type = 'onOrAfter'
 
       if (date < onOrAfter) {
-        return buildMessage(key, { value, message: message || `[ON OR AFTER] date is NOT on or after ${value}` });
+        return buildMessage(key, { type, value, context: { onOrAfter, message }  });
       }
     }
 


### PR DESCRIPTION
### TODO
- [ ] Write tests

## Changes proposed in this pull request
This PR fixes a bug preventing the use of a custom function to generate validation messages when using the date validator. Per the documentation all validators should allow for a custom message handler: https://github.com/poteto/ember-changeset-validations#custom-validation-messages
