### PR TITLE
Change misleading example for class validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ export default class PersonalNoValidator {
 
   async validate(key, newValue, oldValue, changes, content) {
     try {
-      let response = await fetch('/api/personal-no/validation', body: JSON.stringify({ data: newValue }));
-      return response.json();
-    });
+      await fetch('/api/personal-no/validation', body: JSON.stringify({ data: newValue }));
+      
       return true;
     } catch (_) {
       return 'Personal No is invalid';

--- a/README.md
+++ b/README.md
@@ -101,7 +101,14 @@ export default class PersonalNoValidator {
 
   async validate(key, newValue, oldValue, changes, content) {
     try {
-      await fetch('/api/personal-no/validation', body: JSON.stringify({ data: newValue }));
+      await fetch(
+        '/api/personal-no/validation', 
+        { 
+          method: 'POST', 
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data: newValue })
+        }
+      );
       
       return true;
     } catch (_) {

--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ Moreover, as of 3.8.0, a validator can be an Object or Class with a `validate` f
 
 ```js
 import  { inject as service } from '@ember/service';
+import fetch from 'fetch';
 
 export default class PersonalNoValidator {
-  @service ajax;
 
   async validate(key, newValue, oldValue, changes, content) {
     try {
-      await this.ajax.post('/api/personal-no/validation', { data: newValue });
+      let response = await fetch('/api/personal-no/validation', body: JSON.stringify({ data: newValue }));
+      return response.json();
+    });
       return true;
     } catch (_) {
       return 'Personal No is invalid';


### PR DESCRIPTION
The example in README.txt is misleading because it is not straightforward to use services in native class objects.

Services can only be injected in classes that have been instantiated via the Ember DI system. This is not the case with validators.