### PR TITLE
Date validator enhancement: before/after/onOrBefore/onOrAfter accept a function that returns a date

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Validates the length of a `String` or an `Array`.
 
 #### `date`
 
-This API accepts valid Date objects or a Date in milliseconds since Jan 1 1970.  Strings are currently not supported.  It is recommended you use use native JavaScript or you library of choice to generate a date from your data.
+This API accepts valid Date objects or a Date in milliseconds since Jan 1 1970, or a functiom that returns a Date.  Strings are currently not supported.  It is recommended you use use native JavaScript or you library of choice to generate a date from your data.
 
 ```js
 {
@@ -205,6 +205,7 @@ This API accepts valid Date objects or a Date in milliseconds since Jan 1 1970. 
   propertyName: validateDate({ onOrBefore: Date.parse(new Date('3000-01-01')) }), // must be not after 1st Jan. 3000
   propertyName: validateDate({ after: new Date('3000-01-01') }), // must be after 1st Jan. 3000
   propertyName: validateDate({ onOrAfter: new Date('3000-01-01') }), // must be not before 1st Jan. 3000
+  propertyName: validateDate({ onOrAfter: () => new Date() }), // must not be in the past
   propertyName: validateDate({ onOrAfter: '3000-01-01' }), // Error
 }
 ```

--- a/addon/utils/to-date.js
+++ b/addon/utils/to-date.js
@@ -7,6 +7,10 @@
 export default function toDate(argument) {
   const argStr = Object.prototype.toString.call(argument)
 
+  if (typeof argument === "function") {
+    argument = argument()
+  }
+
   if (
     argument instanceof Date ||
     (typeof argument === 'object' && argStr === '[object Date]')

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -119,6 +119,14 @@ module('Unit | Validator | date', function() {
       'date is after "before" date'
     );
 
+    options = { before: () => startDate };
+    validator = validateDate(options);
+    assert.equal(
+      validator(key, afterDate),
+      buildMessage(key, { afterDate, message: `[BEFORE] date is NOT before ${afterDate}` }),
+      'before accepts a function that returns a date'
+    );
+
     options = { before: afterDate };
     validator = validateDate(options);
     assert.equal(
@@ -143,6 +151,14 @@ module('Unit | Validator | date', function() {
       validator(key, afterDate),
       buildMessage(key, { afterDate, message: `[ON OR BEFORE] date is NOT on or before ${afterDate}` }),
       'date is after "onOrBefore" date'
+    );
+
+    options = { onOrBefore: () => startDate };
+    validator = validateDate(options);
+    assert.equal(
+      validator(key, afterDate),
+      buildMessage(key, { afterDate, message: `[ON OR BEFORE] date is NOT on or before ${afterDate}` }),
+      'onOrBefore accepts a function that returns a date'
     );
 
     options = { onOrBefore: afterDate };
@@ -171,6 +187,14 @@ module('Unit | Validator | date', function() {
       'date is after the "after" date'
     );
 
+    options = { after: () => afterDate };
+    validator = validateDate(options);
+    assert.equal(
+      validator(key, startDate),
+      buildMessage(key, { startDate, message: `[AFTER] date is NOT after ${startDate}` }),
+      "after accepts a function that returns a date"
+    );
+
     options = { after: startDate };
     validator = validateDate(options);
     assert.equal(
@@ -195,6 +219,14 @@ module('Unit | Validator | date', function() {
       validator(key, startDate),
       buildMessage(key, { onOrAfterDate, message: `[ON OR AFTER] date is NOT on or after ${startDate}` }),
       'date onOrAfter the "onOrAfter" date is not allowed'
+    );
+
+    options = { onOrAfter: () => onOrAfterDate };
+    validator = validateDate(options);
+    assert.equal(
+      validator(key, startDate),
+      buildMessage(key, { onOrAfterDate, message: `[ON OR AFTER] date is NOT on or after ${startDate}` }),
+      'onOrAfter accepts a function that returns a date'
     );
 
     options = { onOrAfter: startDate };


### PR DESCRIPTION
The Date validator's before/after/onOrBefore/onOrAfter options now
accept a function that returns a date, which is re-evaluated everytime
the validator runs. This allows the date validation logic to
change in between validations, which is useful for situations where
date validation logic is based on date values that may change in between
validations.

Related to #204 
