### PR TITLE
Allow ember-get-config v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-auto-import": "^2.2.3",
     "ember-changeset": "^4.0.0-beta.1",
     "ember-cli-babel": "^7.26.6",
-    "ember-get-config": "^0.3.0 || ^0.4.0 || ^0.5.0",
+    "ember-get-config": "^0.3.0 || ^0.4.0 || ^0.5.0 || ^1.0.0",
     "ember-validators": "~4.0.0",
     "validated-changeset": "~1.1.0"
   },


### PR DESCRIPTION
This allow ember-get-config dependency to be v1.0.0