### PR TITLE
Allow ember-get-config v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-get-config": "^0.3.0 || ^0.4.0 || ^0.5.0 || ^1.0.2",
+    "ember-get-config": "^0.3.0 || ^0.4.0 || ^0.5.0 || ^1.0.2 || ^2.0.0",
     "ember-validators": "~4.1.2",
     "validated-changeset": "~1.3.2"
   },


### PR DESCRIPTION
This allow ember-get-config dependency to be v2.0.0
This addon was forcing the v1 on my app which caused trouble building, started happening yesterday don't know why, with v2 everything works.