### PR TITLE
Update validateConfirmation to support confirmation against fields on ember-data objects

### DIFF
--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -6,7 +6,14 @@ export default function validateConfirmation(options = {}) {
     // Combine the changes on top of the content so that we evaluate against both default values
     // and valid changes. `changes` only has valid changes that have been made and won't include
     // default values
-    let model = Object.assign({}, content, changes);
+    let model;
+
+    if ('_internalModel' in content) {
+      const contentHash = content._internalModel.createSnapshot().attributes();
+      model = Object.assign({}, contentHash, changes);
+    } else {
+      model = Object.assign({}, content, changes);
+    }
 
     let result = evValidateConfirmation(newValue, options, model, key);
     return result === true ? true : buildMessage(key, result);

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -89,3 +89,27 @@ test('It looks for default values as well as "changes" values', function (assert
   );
   assert.true(validator(key, password, undefined, {}, content));
 });
+
+test('It handles ember data models when looking for default values as well as "changes" values', function (assert) {
+  assert.expect(2);
+
+  let password = '1234567';
+  let content = {
+    _internalModel: {
+      createSnapshot: () => ({
+        attributes: () => ({
+          password,
+        }),
+      }),
+    },
+  };
+  let key = 'passwordConfirmation';
+  let opts = { on: 'password' };
+  let validator = validateConfirmation(opts);
+
+  assert.strictEqual(
+    validator(key, 'foo', undefined, {}, content),
+    buildMessage(key, { type: 'confirmation', context: opts })
+  );
+  assert.true(validator(key, password, undefined, {}, content));
+});


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
-->

<!-- If this pull request addresses an issue please provide the issue number here -->


## Changes proposed in this pull request
This addresses the use case I referred to in https://github.com/poteto/ember-changeset-validations/issues/137#issuecomment-1183397001, which is that when `validateConfirmation`'s resulting function receives an ember-data object as its `content`, and the original field (say `password`) is unchanged from that ember-data object, the validating field (say `passwordConfirmation`) is considered invalid, no matter whether it matches the current content or not.

It looks like @brandynbennett took a stab at addressing this issue with #138 (later merged as #219 by @snewcomer), but that only works with POJOs whose top-level keys include the attributes we're targeting, which for ember-data objects are quite nested.

There may be a better way to grab all of an ember-data object's attributes than what I've got here, which admittedly uses their private API so I'm not thrilled about _that_, but it does get the job done. Open to suggestions if there's a better approach folks think we should take, or if the fact that we're seeing ember-data objects instead of POROS in a validator means we're just "doing it wrong" somewhere else in my team's code. 😄 